### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ TIP: My other libries such as [bootstrap.native](https://github.com/thednp/boots
 <script type="text/javascript" src="../assets/js/minifill.min.js"></script>
 
 <!-- if you wanna use JSDELIVR -->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/minifill/0.0.4/minifill.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/thednp/minifill@0.0.4/dist/minifill.min.js"></script>
 
 <!-- if you wanna use CDNJS -->
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/minifill/0.0.4/minifill.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/thednp/minifill.

Feel free to ping me if you have any questions regarding this change.